### PR TITLE
Update repository URL for PowerShell extension

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ version = "0.4.2"
 schema_version = 1
 authors = ["Thanabodee Charoenpiriyakij <wingyminus@gmail.com>"]
 description = "PowerShell support"
-repository = "https://github.com/wingyplus/zed-powershell"
+repository = "https://github.com/zed-extensions/powershell"
 
 [grammars.powershell]
 repository = "https://github.com/airbus-cert/tree-sitter-powershell"


### PR DESCRIPTION
Clicking the repo link on the Extensions page in Zed leads to the wrong (and outdated) repo. Presumably this change would fix that.