### PR TITLE
Add task templates for running PowerShell code (F8 run selection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ If you wish to specify a custom path to your language server, you can do so via 
 }
 ```
 
+## Running PowerShell code
+
+This extension provides task templates for running PowerShell code:
+
+- **PowerShell: Run Selection** — runs the currently selected text
+- **PowerShell: Run File** — runs the current file
+
+These tasks are available via the `task: spawn` action.
+
+To bind `F8` for running selected text (like PowerShell ISE and VS Code), add the following to your `keymap.json`:
+
+```json
+{
+  "context": "Editor && extension == powershell",
+  "bindings": {
+    "f8": ["task::Spawn", { "task_name": "PowerShell: Run Selection" }]
+  }
+}
+```
+
+## Configuring your language server settings
+
 Additionally, you can configure settings for your language server as well as initialization options
 to pass to the language server on start.
 

--- a/languages/powershell/tasks.json
+++ b/languages/powershell/tasks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "label": "PowerShell: Run Selection",
+    "command": "pwsh",
+    "args": ["-NoLogo", "-NoProfile", "-Command", "$ZED_SELECTED_TEXT"]
+  },
+  {
+    "label": "PowerShell: Run File",
+    "command": "pwsh",
+    "args": ["-NoLogo", "-NoProfile", "-File", "$ZED_FILE"]
+  }
+]


### PR DESCRIPTION
## Summary

Add task templates that enable running PowerShell code directly from the editor, addressing the feature request in #10.

> **Note:** Zed extensions cannot ship keybindings — only task templates, grammars, LSP configurations, themes, and slash commands. The F8 binding must be configured by the user in their `keymap.json`. This PR adds the task templates that make that possible and documents the keybinding setup in the README.

## Changes

- **`languages/powershell/tasks.json`** — Two new task templates:
  - **PowerShell: Run Selection** — runs selected text via `pwsh -Command`
  - **PowerShell: Run File** — runs the current file via `pwsh -File`
- **`README.md`** — Documents the new tasks and provides an example keybinding for F8

## How it works

Zed's task system supports `$ZED_SELECTED_TEXT` and `$ZED_FILE` variables. The "Run Selection" task only appears when text is selected (Zed filters tasks with unavailable variables). Users can bind F8 to this task in their `keymap.json`:

```json
{
  "context": "Editor && extension == powershell",
  "bindings": {
    "f8": ["task::Spawn", { "task_name": "PowerShell: Run Selection" }]
  }
}
```

This follows the same pattern used by the Ruby and PHP extensions for their run-selection tasks.

Closes #10
